### PR TITLE
Prevent TypeError on invocation when options are not passed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Change Log
+All notable changes to this project will be documented in this file.
+This project adheres to [Semantic Versioning](http://semver.org/).
+
+## [0.2.1]
+### Fixed
+- Initialization without opts.expiry passed causes TypeError.

--- a/lib/electrode-keepalive.js
+++ b/lib/electrode-keepalive.js
@@ -11,7 +11,8 @@ const FIVE_SECONDS_IN_MS = 5000;
 let DNS_CACHE = {};
 
 class ElectrodeKeepAlive {
-  constructor(opts = {}) {
+  constructor(opts) {
+    opts = opts || {};
     this.expiry = opts.expiry || FIVE_SECONDS_IN_MS;
     this._https = opts.https;
     this._agent = opts.https ? new https.Agent(opts) : new http.Agent(opts);

--- a/lib/electrode-keepalive.js
+++ b/lib/electrode-keepalive.js
@@ -11,7 +11,7 @@ const FIVE_SECONDS_IN_MS = 5000;
 let DNS_CACHE = {};
 
 class ElectrodeKeepAlive {
-  constructor(opts) {
+  constructor(opts = {}) {
     this.expiry = opts.expiry || FIVE_SECONDS_IN_MS;
     this._https = opts.https;
     this._agent = opts.https ? new https.Agent(opts) : new http.Agent(opts);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "electrode-keepalive",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "electrode-keepalive",
   "main": "lib/electrode-keepalive.js",
   "scripts": {


### PR DESCRIPTION
Since you have default values, one shouldn't be required to pass anything. Unfortunately `Unhandled rejection TypeError: Cannot read property 'expiry' of undefined - electrode-keepalive.js:15:23` is thrown on instantiation. 